### PR TITLE
Change rgl.* to *3d

### DIFF
--- a/R/image_x3p.R
+++ b/R/image_x3p.R
@@ -67,7 +67,7 @@ x3p_image <- function(x3p, file = NULL, col = "#cd7f32",
   
   if (!update) { 
     open3d(params = params)
-    rgl.pop("lights")
+    pop3d("lights")
     light3d(
       x = xyz, diffuse = "gray40",
       specular = "gray40", ambient = "grey10", viewpoint.rel = TRUE
@@ -107,7 +107,7 @@ x3p_image <- function(x3p, file = NULL, col = "#cd7f32",
   p
   if (!is.null(file)) {
     x3p_snapshot(file)
-    rgl.close()
+    close3d()
   }
   invisible(p) 
 }

--- a/R/x3p_mask_legend.R
+++ b/R/x3p_mask_legend.R
@@ -95,5 +95,5 @@ x3p_darker <- function() {
   stopifnot(length(rgl.dev.list()) > 0)
   # stopifnot("x3p" %in% class(x3p)) # no x3p object
 
-  rgl.pop("lights")
+  pop3d("lights")
 }

--- a/tests/testthat/test_image_x3p.R
+++ b/tests/testthat/test_image_x3p.R
@@ -29,7 +29,7 @@ test_that("image_x3p works as expected", {
   expect_gte(rglwindowopen, 1)
   # If open, close it
   if (rglwindowopen) {
-    rgl::rgl.close()
+    rgl::close3d()
   }
   x3ptest2 <- x3ptest %>% x3p_add_grid(spaces = 2, size = 1, color = "black")
   image_x3p(x3ptest2, file = "x3ptest.png")
@@ -45,7 +45,7 @@ test_that("image_x3p works as expected", {
   expect_gte(rglwindowopen, 1)
   # If open, close it
   if (rglwindowopen) {
-    rgl::rgl.close()
+    rgl::close3d()
   }
 
   # With mask
@@ -57,7 +57,7 @@ test_that("image_x3p works as expected", {
   expect_gte(rglwindowopen, 1)
   # If open, close it
   if (rglwindowopen) {
-    rgl::rgl.close()
+    rgl::close3d()
   }
 
   expect_warning(
@@ -69,6 +69,6 @@ test_that("image_x3p works as expected", {
   expect_gte(rglwindowopen, 1)
   # If open, close it
   if (rglwindowopen) {
-    rgl::rgl.close()
+    rgl::close3d()
   }
 })

--- a/tests/testthat/test_x3p_mask_legend.R
+++ b/tests/testthat/test_x3p_mask_legend.R
@@ -8,13 +8,13 @@ test_that("x3p_darker", {
     x3p_add_mask() %>%
     image_x3p()
 
-  lights <- rgl::rgl.ids(type = "lights")
+  lights <- rgl::ids3d(type = "lights")
 
   x3p_darker()
 
-  lights2 <- rgl::rgl.ids(type = "lights")
+  lights2 <- rgl::ids3d(type = "lights")
 
-  rgl::rgl.close()
+  rgl::close3d()
   expect_lt(nrow(lights2), nrow(lights))
 })
 
@@ -26,13 +26,13 @@ test_that("x3p_lighter", {
     x3p_add_mask() %>%
     image_x3p()
 
-  lights <- rgl::rgl.ids(type = "lights")
+  lights <- rgl::ids3d(type = "lights")
 
   x3p_lighter()
 
-  lights2 <- rgl::rgl.ids(type = "lights")
+  lights2 <- rgl::ids3d(type = "lights")
 
-  rgl::rgl.close()
+  rgl::close3d()
 
   expect_gt(nrow(lights2), nrow(lights))
 })
@@ -51,7 +51,7 @@ test_that("x3p_add_legend", {
 
   objs2 <- rgl::rgl.attrib.info(showAll = T)
 
-  rgl::rgl.close()
+  rgl::close3d()
   extra_stuff <- dplyr::anti_join(objs2, objs)
   expect_gt(nrow(extra_stuff), 0) # TODO: Actually test for background? Not sure how to get at that...
 
@@ -65,7 +65,7 @@ test_that("x3p_add_legend", {
 
   objs2 <- rgl::rgl.attrib.info(showAll = T)
 
-  rgl::rgl.close()
+  rgl::close3d()
   extra_stuff <- dplyr::anti_join(objs2, objs)
   expect_gt(nrow(extra_stuff), 0) # TODO: Actually test for background? Not sure how to get at that...
 })


### PR DESCRIPTION
Some upcoming changes to the rgl package will require changes to
x3ptools.  I will be deprecating a number of rgl.* function calls.
You can read about the issues here:

        https://dmurdoch.github.io/rgl/articles/deprecation.html

I have made the required changes to x3ptools in the attached patch. These changes should work with both old and new rgl versions.